### PR TITLE
fix: Fixed an issue where setting “Show Source Graphics” to true in Inspector would hide the SubMesh in TextMeshPro.

### DIFF
--- a/Packages/src/Editor/CompositeCanvasRendererEditor.cs
+++ b/Packages/src/Editor/CompositeCanvasRendererEditor.cs
@@ -153,6 +153,7 @@ namespace CompositeCanvas
 
             if (EditorGUI.EndChangeCheck())
             {
+                serializedObject.ApplyModifiedProperties();
                 foreach (var renderer in targets.OfType<CompositeCanvasRenderer>())
                 {
                     renderer.SetSourcesMaterialDirty();


### PR DESCRIPTION
https://github.com/user-attachments/assets/78124318-1e79-415e-8ab4-565d9ec482b8

As you can see in the attached video, when there is a submesh in TextMeshPro and “Show Source Graphics” is set to On, the submesh disappears in the editor. This problem has been fixed.