### PR TITLE
fix: Fixed an issue with TextMeshPro not baking properly in Unity6.

### DIFF
--- a/Packages/src/Runtime/CompositeCanvasProcess.cs
+++ b/Packages/src/Runtime/CompositeCanvasProcess.cs
@@ -96,6 +96,16 @@ namespace CompositeCanvas
                 source.mesh.SetColors(colors);
                 ListPool<Color32>.Return(ref colors);
 
+#if UNITY_6000_0_OR_NEWER
+                if (source.graphic.canvas.renderMode == RenderMode.ScreenSpaceCamera)
+                {
+                    var uv1s = ListPool<Vector2>.Rent();
+                    graphicMesh.GetUVs(0, uv1s);
+                    source.mesh.SetUVs(0, uv1s);
+                    ListPool<Vector2>.Return(ref uv1s);
+                }
+#endif
+
                 if (!source.renderer.perspectiveBaking)
                 {
                     var xScale = 1f / source.graphic.canvas.rootCanvas.transform.lossyScale.x;


### PR DESCRIPTION
In Unity6, when the Canvas is ScreenSpaceCamera, TextMeshPro is not baked correctly, and a blurry or light colored square mesh is displayed.
This is affected by the Fov of the Camera and the Plane Distance of the Canvas.

<img width="645" alt="スクリーンショット 2025-03-24 22 12 31" src="https://github.com/user-attachments/assets/4b545fa0-fa5b-41de-aa57-d4174d2b4bb7" />


### reproduction procedure

1. Open the file in Unity6 (I tried with 6000.0.35f1)
2. Enable “TMP_ENABLE” in Script Define Symbols.
3. Place TextMeshPro in the Canvas.
4. Set the Canvas to Screen Space Camera and set RenderCamera.
5. Set Canvas Scaler to "UIScaleMode: Scale With Screen Size" and "Reference Resolution" to x: 1920, y: 1080. 
6. Attach "CompositCanvasRenderer" to Canvas, set "Baking Trigger" to "Always", and set "Show Source Graphics" to Off. 
7. Decrease the "Plane Distance" of the Canvas and the fov of the Camera. Text will be blurred.