### PR TITLE
fix: CompositeCanvasRenderer does not reflect inactive CompositeCanvasSource GameObjects

### DIFF
--- a/Packages/src/Runtime/CompositeCanvasRenderer.cs
+++ b/Packages/src/Runtime/CompositeCanvasRenderer.cs
@@ -1107,6 +1107,17 @@ namespace CompositeCanvas
             Profiler.EndSample();
         }
 
+        public void ClearBakeBuffer()
+        {
+            if (!_bakeBuffer) return;
+
+            _cb.Clear();
+            _cb.SetRenderTarget(_bakeBuffer);
+            _cb.ClearRenderTarget(true, true, Color.clear, 1f);
+            Graphics.ExecuteCommandBuffer(_cb);
+            SetDirty();
+        }
+
 #if UNITY_EDITOR
         /// <summary>
         /// Editor-only function that Unity calls when the script is loaded or a value changes in the Inspector.

--- a/Packages/src/Runtime/CompositeCanvasSource.cs
+++ b/Packages/src/Runtime/CompositeCanvasSource.cs
@@ -176,6 +176,11 @@ namespace CompositeCanvas
             }
 #endif
 
+            if (_graphic && renderer && renderer.isActiveAndEnabled)
+            {
+                renderer.ClearBakeBuffer();
+            }
+
             MeshExtensions.Return(ref _mesh);
             s_MaterialPropertyBlockPool.Return(ref _mpb);
             UpdateRenderer(null);


### PR DESCRIPTION
This always occurs in TextMeshPro.
It also occurs with other Graphic components, such as the Image component, although the exact conditions are unknown.

It is easier to understand if you check with “Show Source Graphics” of CompositeCanvasRenderer turned off.