### PR TITLE
fix: Incorrect range handling of Scripting Define Symbols

### DIFF
--- a/Packages/src/Runtime/CompositeCanvasSource.cs
+++ b/Packages/src/Runtime/CompositeCanvasSource.cs
@@ -451,6 +451,6 @@ namespace CompositeCanvas
                 _tmpMaterialChanged = false;
             }
         }
-    }
 #endif
+    }
 }


### PR DESCRIPTION
Sorry, there was a problem with the Scripting Define Symbols range we did in the [previous PR](https://github.com/mob-sakai/CompositeCanvasRenderer/pull/8), and we have corrected it.