### PR TITLE
feat: Changed Render texture format to selectable

### DIFF
--- a/Packages/src/Editor/CompositeCanvasRendererEditor.cs
+++ b/Packages/src/Editor/CompositeCanvasRendererEditor.cs
@@ -39,6 +39,7 @@ namespace CompositeCanvas
         private SerializedProperty _srcBlendMode;
         private SerializedProperty _useCanvasScaler;
         private SerializedProperty _useStencil;
+        private SerializedProperty _renderTextureFormat;
         private SerializedProperty _viewType;
 
         protected override void OnEnable()
@@ -54,6 +55,7 @@ namespace CompositeCanvas
             _extents = serializedObject.FindProperty("m_Extents");
             _culling = serializedObject.FindProperty("m_Culling");
             _useStencil = serializedObject.FindProperty("m_UseStencil");
+            _renderTextureFormat = serializedObject.FindProperty("m_RenderTextureFormat");
             _bakingTrigger = serializedObject.FindProperty("m_BakingTrigger");
             _viewType = serializedObject.FindProperty("m_ViewType");
             _colorMode = serializedObject.FindProperty("m_ColorMode");
@@ -87,6 +89,7 @@ namespace CompositeCanvas
             EditorGUILayout.PropertyField(_useCanvasScaler);
             EditorGUILayout.PropertyField(_extents);
             EditorGUILayout.PropertyField(_useStencil);
+            EditorGUILayout.PropertyField(_renderTextureFormat);
             EditorGUILayout.PropertyField(_sharingGroupId);
             ShowPrimaryRenderer();
 

--- a/Packages/src/Runtime/Internal/Utilities/RenderTextureRepository.cs
+++ b/Packages/src/Runtime/Internal/Utilities/RenderTextureRepository.cs
@@ -13,10 +13,6 @@ namespace Coffee.CompositeCanvasRendererInternal
     {
         private static readonly ObjectRepository<RenderTexture> s_Repository = new ObjectRepository<RenderTexture>();
 
-        private static readonly GraphicsFormat s_GraphicsFormat = GraphicsFormatUtility.GetGraphicsFormat(
-            RenderTextureFormat.ARGB32,
-            RenderTextureReadWrite.Default);
-
 #if UNITY_2021_3_OR_NEWER
         private static readonly GraphicsFormat s_StencilFormat = GraphicsFormatUtility.GetDepthStencilFormat(0, 8);
 #endif
@@ -55,13 +51,14 @@ namespace Coffee.CompositeCanvasRendererInternal
         /// <summary>
         /// Adds or retrieves a cached RenderTexture based on the hash.
         /// </summary>
-        public static RenderTextureDescriptor GetDescriptor(Vector2Int size, bool useStencil)
+        public static RenderTextureDescriptor GetDescriptor(Vector2Int size, bool useStencil, RenderTextureFormat format)
         {
             Profiler.BeginSample("(COF)[RTRepository] GetDescriptor");
+            GraphicsFormat graphicsFormat = GraphicsFormatUtility.GetGraphicsFormat(format, RenderTextureReadWrite.Default);
             var rtd = new RenderTextureDescriptor(
                 Mathf.Max(8, size.x),
                 Mathf.Max(8, size.y),
-                s_GraphicsFormat,
+                graphicsFormat,
                 useStencil ? 24 : 0)
             {
                 sRGB = QualitySettings.activeColorSpace == ColorSpace.Linear,


### PR DESCRIPTION
## Description

- Added the ability to choose the format of the internally generated rendere texture.
- This is because we wanted to create an effect using HDR Color. For example, like the post effect bloom, where the effect is applied to areas where the luminance exceeds a threshold value.

## Type of change

Please write the commit message in the format corresponding to the change type.
Please see [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for more information.

- [x] New feature (non-breaking change which adds functionality)  

## Test environment

- Platform: [e.g. Editor(Windows/Mac), Standalone(Windows/Mac), iOS, Android, WebGL]
- Unity version: Unity 6000.0.41f1, 2021.3.51, 2019.4.40
- Build options: [URP]

## Checklist

- [x] This pull request is for merging into the `develop` branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
