### PR TITLE
feat: add debug names for RenderTexture and CommandBuffer

### DIFF
--- a/Packages/src/Runtime/CompositeCanvasRenderer.cs
+++ b/Packages/src/Runtime/CompositeCanvasRenderer.cs
@@ -337,9 +337,16 @@ namespace CompositeCanvas
                     if (!RenderTextureRepository.Valid(hash, _bakeBuffer))
                     {
                         RenderTextureRepository.Get(hash, ref _bakeBuffer,
-                            x => new RenderTexture(RenderTextureRepository.GetDescriptor(x.rtSize, x.useStencil, x.renderTextureFormat))
-                            {
-                                hideFlags = HideFlags.DontSave
+                            x => {
+                                var rt = new RenderTexture(RenderTextureRepository.GetDescriptor(x.rtSize, x.useStencil, x.renderTextureFormat));
+                                rt.hideFlags = HideFlags.DontSave;
+                                
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+                                // Set detailed name for identification in Memory Profiler and Frame Debugger
+                                rt.name = $"[CCR] {gameObject.name} {x.rtSize.x}x{x.rtSize.y} {x.renderTextureFormat}";
+#endif
+                                
+                                return rt;
                             }, (rtSize, useStencil, renderTextureFormat));
                     }
 
@@ -932,7 +939,12 @@ namespace CompositeCanvas
             {
                 Profiler.BeginSample("(CCR)[CompositeCanvasRenderer] Bake > Rent cb");
                 _cb = s_CommandBufferPool.Rent();
-                _cb.name = "[CompositeCanvasRenderer] Bake";
+                
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+                // Set detailed name for identification in Memory Profiler and Frame Debugger
+                _cb.name = $"[CCR] Bake: {gameObject.name}";
+#endif
+                
                 Profiler.EndSample();
             }
 


### PR DESCRIPTION
## Description

This PR adds descriptive naming for RenderTexture and CommandBuffer objects in CompositeCanvasRenderer to improve debugging experience in Memory Profiler and Frame Debugger.

### Summary of changes:
- Added conditional naming for RenderTexture objects with format: `[CCR] {gameObjectName} {width}x{height} {format}`
- Added conditional naming for CommandBuffer objects with format: `[CCR] Bake: {gameObjectName}`
- Names are only set when `UNITY_EDITOR` or `DEVELOPMENT_BUILD` is defined
- Zero performance impact in release builds as string generation is completely skipped

### Context:
This change enables developers to:
- Quickly identify CompositeCanvasRenderer resources in Memory Profiler
- Filter and search for specific instances using the `[CCR]` prefix
- Distinguish between different CompositeCanvasRenderer instances by GameObject name
- Analyze memory usage patterns more effectively

No dependencies are required for this change.

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update documentations
- [ ] Others (refactoring, style changes, etc.)

## Test environment

- Platform: Editor(Mac)
- Unity version: 2019.4.40f1, 2022.3.0f1,  6000,0.41f1
- Build options: IL2CPP, .Net Standard 2.1

## Checklist

- [x] This pull request is for merging into the `develop` branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

