### PR TITLE
fix: CompositeCanvasRenderer not supporting RectMask2D

### DIFF
--- a/Packages/src/Shaders/UI-CompositeCanvasRenderer.shader
+++ b/Packages/src/Shaders/UI-CompositeCanvasRenderer.shader
@@ -199,7 +199,8 @@ Shader "UI/CompositeCanvasRenderer"
                 color *= tex2D(_MaskTex, maskUv + _Time.y * _MaskSpeed).a;
                 #endif
 
-                return applyColor(color, IN.color);
+                half4 colorFactor = half4(IN.color.rgb, IN.color.a * color.a);
+                return applyColor(color, colorFactor);
             }
             ENDCG
         }


### PR DESCRIPTION
## Description

  - Fixed an issue where CompositeCanvasRenderer was not compatible with RectMask2D component

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
  - [ ] Update documentations
  - [ ] Others (refactoring, style changes, etc.)

  ## Test environment

  - Platform: Editor(Windows/Mac), Standalone(Windows/Mac)
  - Unity version: 2019.4+

  ## Checklist

  - [ x] This pull request is for merging into the `develop` branch
  - [ x] My code follows the style guidelines of this project
  - [ x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ x] My changes generate no new warnings
  - [ x] I have checked my code and corrected any misspellings