### PR TITLE
feat: add custom shader support for CompositeCanvasRenderer

### DIFF
--- a/Packages/src/Runtime/CompositeCanvasRenderer.cs
+++ b/Packages/src/Runtime/CompositeCanvasRenderer.cs
@@ -744,12 +744,26 @@ namespace CompositeCanvas
         }
 
         /// <summary>
+        /// Get shader to use based on project settings.
+        /// </summary>
+        private static Shader GetShaderToUse()
+        {
+            var customShader = CompositeCanvasRendererProjectSettings.customShader;
+            if (customShader != null)
+            {
+                return customShader;
+            }
+            
+            return Shader.Find("UI/CompositeCanvasRenderer");
+        }
+
+        /// <summary>
         /// Create a material.
         /// </summary>
         public static Material CreateMaterial(ColorMode colorMode, BlendMode srcBlendMode, BlendMode dstBlendMode)
         {
             Profiler.BeginSample("(CCR)[CompositeCanvasRenderer] CreateMaterial");
-            var mat = new Material(Shader.Find("UI/CompositeCanvasRenderer"))
+            var mat = new Material(GetShaderToUse())
             {
                 hideFlags = HideFlags.DontSave | HideFlags.NotEditable,
                 shaderKeywords = s_ColorModeKeywords[(int)colorMode]

--- a/Packages/src/Runtime/ProjectSettings/CompositeCanvasRendererProjectSettings.cs
+++ b/Packages/src/Runtime/ProjectSettings/CompositeCanvasRendererProjectSettings.cs
@@ -19,6 +19,11 @@ namespace CompositeCanvas
         [SerializeField]
         private bool m_EnableCullingInEditMode = true;
 
+        [Header("CompositeCanvasRenderer Shader Override")]
+        [SerializeField]
+        [Tooltip("Alternative shader to use instead of 'UI/CompositeCanvasRenderer'.\nLeave empty to use the default shader.")]
+        private Shader m_CustomShader;
+
 #if UNITY_EDITOR
         [Header("Shader")]
         [SerializeField]
@@ -57,6 +62,12 @@ namespace CompositeCanvas
                     default: return 1f / (1 << (int)instance.m_TransformSensitivity);
                 }
             }
+        }
+
+        public static Shader customShader
+        {
+            get => instance.m_CustomShader;
+            set => instance.m_CustomShader = value;
         }
 
 #if UNITY_EDITOR

--- a/Packages/src/Shaders/UI-CompositeCanvasRenderer.shader
+++ b/Packages/src/Shaders/UI-CompositeCanvasRenderer.shader
@@ -199,7 +199,8 @@ Shader "UI/CompositeCanvasRenderer"
                 color *= tex2D(_MaskTex, maskUv + _Time.y * _MaskSpeed).a;
                 #endif
 
-                return applyColor(color, IN.color);
+                half4 colorFactor = half4(IN.color.rgb, IN.color.a * color.a);
+                return applyColor(color, colorFactor);
             }
             ENDCG
         }


### PR DESCRIPTION
  ## Description

 Fixes #22 

  This PR adds support for custom shader override in CompositeCanvasRenderer through ProjectSettings. Users can
  now specify an alternative shader to replace the default "UI/CompositeCanvasRenderer" shader used by all
  CompositeCanvasRenderer components.

  **Key Changes:**
  - Add customShader setting to ProjectSettings
  - Allow overriding default UI/CompositeCanvasRenderer shader
  - Maintain MaterialRepository caching compatibility

  **Motivation:**
  This feature enables users to customize the rendering behavior of CompositeCanvasRenderer by using their own
  shaders while preserving all existing functionality and performance optimizations.

  ## Type of change

  Please write the commit message in the format corresponding to the change type.
  Please see [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for more information.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Update documentations
  - [ ] Others (refactoring, style changes, etc.)

  ## Test environment

  - Platform: Editor(Mac)
  - Unity version: 2023.2+
  - Build options: IL2CPP, .Net Standard 2.1

  ## Checklist

  - [x] This pull request is for merging into the `develop` branch
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have checked my code and corrected any misspellings