### PR TITLE
feat: add new blur modes: separate axes and motion blur

### DIFF
--- a/Packages/src/Runtime/Effects/CompositeCanvasBloom.cs
+++ b/Packages/src/Runtime/Effects/CompositeCanvasBloom.cs
@@ -17,6 +17,7 @@ namespace CompositeCanvas.Effects
             compositeCanvasRenderer.showSourceGraphics = true;
             compositeCanvasRenderer.color = new Color(1, 1, 1, 0.5f);
             blur = 1f;
+            blurMode = BlurMode.Uniform;
             iteration = 10;
             power = 2f;
             multiplier = 1.5f;

--- a/Packages/src/Runtime/Effects/CompositeCanvasBlur.cs
+++ b/Packages/src/Runtime/Effects/CompositeCanvasBlur.cs
@@ -319,6 +319,7 @@ namespace CompositeCanvas.Effects
                 }
             }
 
+            // Copy to result if last pass rendered into temporary buffer
             if (rtSrc != result)
                 cb.CopyTexture(ShaderPropertyIds.tmpRt, result);
 
@@ -344,7 +345,7 @@ namespace CompositeCanvas.Effects
 
             for (var i = 0; i < m_Iteration; i++)
             {
-                // Vertical blur
+                // Directional blur
                 cb.SetGlobalVector(ShaderPropertyIds.blur, new Vector4(blurValueX, blurValueY));
 
                 if (i == iteration - 1 && useCutoffPass)
@@ -362,6 +363,7 @@ namespace CompositeCanvas.Effects
                 }
             }
 
+            // Copy to result if last pass rendered into temporary buffer
             if (rtSrc != result)
                 cb.CopyTexture(ShaderPropertyIds.tmpRt, result);
 

--- a/Packages/src/Runtime/Effects/CompositeCanvasBlur.cs
+++ b/Packages/src/Runtime/Effects/CompositeCanvasBlur.cs
@@ -1,4 +1,6 @@
+using System;
 using Coffee.CompositeCanvasRendererInternal;
+using CompositeCanvas.Enums;
 using UnityEngine;
 using UnityEngine.Profiling;
 using UnityEngine.Rendering;
@@ -9,9 +11,20 @@ namespace CompositeCanvas.Effects
     public class CompositeCanvasBlur : CompositeCanvasEffectBase
     {
         [Header("Blur Settings")]
-        [Range(0, 1)]
+        [SerializeField]
+        private BlurMode m_BlurMode = BlurMode.Uniform;
+
+        [Range(0, 10)]
         [SerializeField]
         private float m_Blur = 0.5f;
+
+        [Range(-10, 10)]
+        [SerializeField]
+        private float m_BlurX = 0.5f;
+
+        [Range(-10, 10)]
+        [SerializeField]
+        private float m_BlurY = 0.5f;
 
         [Range(1, 10)]
         [SerializeField]
@@ -31,16 +44,56 @@ namespace CompositeCanvas.Effects
 
         private Material _material;
 
+        public BlurMode blurMode
+        {
+            get => m_BlurMode;
+            set
+            {
+                if (m_BlurMode == value) return;
+
+                m_BlurMode = value;
+                SetRendererDirty();
+            }
+        }
+
         public float blur
         {
             get => m_Blur;
             set
             {
-                value = Mathf.Clamp01(value);
+                value = Mathf.Clamp(value, 0, 10);
                 if (Mathf.Approximately(m_Blur, value)) return;
 
                 m_Blur = value;
                 SetRendererDirty();
+            }
+        }
+
+        public float blurX
+        {
+            get => m_BlurX;
+            set
+            {
+                value = Mathf.Clamp(value, -10, 10);
+                if (Mathf.Approximately(m_BlurX, value)) return;
+
+                m_BlurX = value;
+                if(m_BlurMode != BlurMode.Uniform)
+                    SetRendererDirty();
+            }
+        }
+
+        public float blurY
+        {
+            get => m_BlurY;
+            set
+            {
+                value = Mathf.Clamp(value, -10, 10);
+                if (Mathf.Approximately(m_BlurY, value)) return;
+
+                m_BlurY = value;
+                if(m_BlurMode != BlurMode.Uniform)
+                    SetRendererDirty();
             }
         }
 
@@ -127,10 +180,16 @@ namespace CompositeCanvas.Effects
 
             var scale = w / compositeCanvasRenderer.renderingSize.x;
             var blurValue = blur * scale;
+            var blurValueX = blurX * scale;
+            var blurValueY = blurY * scale;
+
             Profiler.EndSample();
 
-            // Skip if blur value is zero.
-            if (blurValue <= 0 && !useCutoffPass) return;
+            var willRenderBlur = blurMode == BlurMode.Uniform && blurValue > 0
+                                  || blurMode != BlurMode.Uniform && (!Mathf.Approximately(blurValueX, 0) || !Mathf.Approximately(blurValueY, 0));
+
+            // Skip if won't render blur.
+            if (!willRenderBlur && !useCutoffPass) return;
 
             // Get blur material
             Profiler.BeginSample("(CCR)[CompositeCanvasBlur] ApplyBakedEffect > Get blur material (lambda)");
@@ -141,37 +200,24 @@ namespace CompositeCanvas.Effects
                     hideFlags = HideFlags.DontSave | HideFlags.NotEditable
                 });
             Profiler.EndSample();
-            if (0 < blurValue)
+
+            var blurRendered = false;
+
+            switch (m_BlurMode)
             {
-                Profiler.BeginSample("(CCR)[CompositeCanvasBlur] ApplyBakedEffect > Construct blur effect for cb");
-                cb.GetTemporaryRT(ShaderPropertyIds.tmpRt, w, h, 0, FilterMode.Bilinear);
-                for (var i = 0; i < m_Iteration; i++)
-                {
-                    // Horizontal blur
-                    cb.SetGlobalVector(ShaderPropertyIds.blur, new Vector4(blurValue, 0));
-                    cb.Blit(result, ShaderPropertyIds.tmpRt, _material, 0);
-
-                    // Vertical blur
-                    cb.SetGlobalVector(ShaderPropertyIds.blur, new Vector4(0, blurValue));
-                    if (i == iteration - 1 && useCutoffPass)
-                    {
-                        // blur and cutoff
-                        cb.SetGlobalFloat(ShaderPropertyIds.innerCutoff, innerCutoff);
-                        cb.SetGlobalFloat(ShaderPropertyIds.power, power);
-                        cb.SetGlobalFloat(ShaderPropertyIds.multiplier, multiplier);
-                        cb.SetGlobalFloat(ShaderPropertyIds.limit, limit);
-                        cb.Blit(ShaderPropertyIds.tmpRt, result, _material);
-                    }
-                    else
-                    {
-                        cb.Blit(ShaderPropertyIds.tmpRt, result, _material, 0);
-                    }
-                }
-
-                cb.ReleaseTemporaryRT(ShaderPropertyIds.tmpRt);
-                Profiler.EndSample();
+                case BlurMode.Uniform:
+                    blurRendered = RenderBlurUniform(cb, w, h, result);
+                    break;
+                case BlurMode.SeparateAxis:
+                    blurRendered = RenderBlurSeparateAxis(cb, w, h, result);
+                    break;
+                case BlurMode.Motion:
+                default:
+                    blurRendered = RenderBlurMotion(cb, w, h, result);
+                    break;
             }
-            else if (useCutoffPass)
+
+            if (!blurRendered && useCutoffPass)
             {
                 Profiler.BeginSample("(CCR)[CompositeCanvasBlur] ApplyBakedEffect > Construct cutoff effect for cb");
                 cb.GetTemporaryRT(ShaderPropertyIds.tmpRt, w, h, 0, FilterMode.Bilinear);
@@ -187,6 +233,154 @@ namespace CompositeCanvas.Effects
                 cb.ReleaseTemporaryRT(ShaderPropertyIds.tmpRt);
                 Profiler.EndSample();
             }
+        }
+
+        private bool RenderBlurUniform(CommandBuffer cb, int w, int h, RenderTargetIdentifier result)
+        {
+            var scale = w / compositeCanvasRenderer.renderingSize.x;
+            var blurValue = blur * scale;
+
+            if(blurValue <= 0)
+                return false;
+
+            Profiler.BeginSample("(CCR)[CompositeCanvasBlur] ApplyBakedEffect > Construct blur effect for cb");
+            cb.GetTemporaryRT(ShaderPropertyIds.tmpRt, w, h, 0, FilterMode.Bilinear);
+            for (var i = 0; i < m_Iteration; i++)
+            {
+                // Horizontal blur
+                cb.SetGlobalVector(ShaderPropertyIds.blur, new Vector4(blurValue, 0));
+                cb.Blit(result, ShaderPropertyIds.tmpRt, _material, 0);
+
+                // Vertical blur
+                cb.SetGlobalVector(ShaderPropertyIds.blur, new Vector4(0, blurValue));
+
+                if (i == iteration - 1 && useCutoffPass)
+                {
+                    // blur and cutoff
+                    cb.SetGlobalFloat(ShaderPropertyIds.innerCutoff, innerCutoff);
+                    cb.SetGlobalFloat(ShaderPropertyIds.power, power);
+                    cb.SetGlobalFloat(ShaderPropertyIds.multiplier, multiplier);
+                    cb.SetGlobalFloat(ShaderPropertyIds.limit, limit);
+                    cb.Blit(ShaderPropertyIds.tmpRt, result, _material);
+                }
+                else
+                {
+                    cb.Blit(ShaderPropertyIds.tmpRt, result, _material, 0);
+                }
+            }
+
+            cb.ReleaseTemporaryRT(ShaderPropertyIds.tmpRt);
+            Profiler.EndSample();
+
+            return true;
+        }
+
+        private bool RenderBlurSeparateAxis(CommandBuffer cb, int w, int h, RenderTargetIdentifier result)
+        {
+            var scale = w / compositeCanvasRenderer.renderingSize.x;
+            var blurValueX = blurX * scale;
+            var blurValueY = blurY * scale;
+
+            if(Mathf.Approximately(blurValueX, 0) && Mathf.Approximately(blurValueY, 0))
+                return false;
+
+            Profiler.BeginSample("(CCR)[CompositeCanvasBlur] ApplyBakedEffect > Construct blur effect for cb");
+            cb.GetTemporaryRT(ShaderPropertyIds.tmpRt, w, h, 0, FilterMode.Bilinear);
+            var rtSrc = result;
+            var rtDst = new RenderTargetIdentifier(ShaderPropertyIds.tmpRt);
+
+            for (var i = 0; i < m_Iteration; i++)
+            {
+                // Horizontal blur
+                if(blurValueX > 0 && m_BlurMode != BlurMode.Motion)
+                {
+                    cb.SetGlobalVector(ShaderPropertyIds.blur, new Vector4(blurValueX, 0));
+                    BlitSwapchain(cb, ref rtSrc, ref rtDst, _material, 0);
+                }
+
+                // Vertical blur
+                cb.SetGlobalVector(ShaderPropertyIds.blur, new Vector4(0, blurValueY));
+
+                if (i == iteration - 1 && useCutoffPass)
+                {
+                    // blur and cutoff
+                    cb.SetGlobalFloat(ShaderPropertyIds.innerCutoff, innerCutoff);
+                    cb.SetGlobalFloat(ShaderPropertyIds.power, power);
+                    cb.SetGlobalFloat(ShaderPropertyIds.multiplier, multiplier);
+                    cb.SetGlobalFloat(ShaderPropertyIds.limit, limit);
+                    if(blurValueY > 0)
+                        BlitSwapchain(cb, ref rtSrc, ref rtDst, _material);
+                    else
+                        BlitSwapchain(cb, ref rtSrc, ref rtDst, _material, 1);
+                }
+                else if(blurValueY > 0)
+                {
+                    BlitSwapchain(cb, ref rtSrc, ref rtDst, _material, 0);
+                }
+            }
+
+            if (rtSrc != result)
+                cb.CopyTexture(ShaderPropertyIds.tmpRt, result);
+
+            cb.ReleaseTemporaryRT(ShaderPropertyIds.tmpRt);
+            Profiler.EndSample();
+
+            return true;
+        }
+
+        private bool RenderBlurMotion(CommandBuffer cb, int w, int h, RenderTargetIdentifier result)
+        {
+            var scale = w / compositeCanvasRenderer.renderingSize.x;
+            var blurValueX = blurX * scale;
+            var blurValueY = blurY * scale;
+
+            if(Mathf.Approximately(blurValueX, 0) && Mathf.Approximately(blurValueY, 0))
+                return false;
+
+            Profiler.BeginSample("(CCR)[CompositeCanvasBlur] ApplyBakedEffect > Construct blur effect for cb");
+            cb.GetTemporaryRT(ShaderPropertyIds.tmpRt, w, h, 0, FilterMode.Bilinear);
+            var rtSrc = result;
+            var rtDst = new RenderTargetIdentifier(ShaderPropertyIds.tmpRt);
+
+            for (var i = 0; i < m_Iteration; i++)
+            {
+                // Vertical blur
+                cb.SetGlobalVector(ShaderPropertyIds.blur, new Vector4(blurValueX, blurValueY));
+
+                if (i == iteration - 1 && useCutoffPass)
+                {
+                    // blur and cutoff
+                    cb.SetGlobalFloat(ShaderPropertyIds.innerCutoff, innerCutoff);
+                    cb.SetGlobalFloat(ShaderPropertyIds.power, power);
+                    cb.SetGlobalFloat(ShaderPropertyIds.multiplier, multiplier);
+                    cb.SetGlobalFloat(ShaderPropertyIds.limit, limit);
+                    BlitSwapchain(cb, ref rtSrc, ref rtDst, _material);
+                }
+                else
+                {
+                    BlitSwapchain(cb, ref rtSrc, ref rtDst, _material, 0);
+                }
+            }
+
+            if (rtSrc != result)
+                cb.CopyTexture(ShaderPropertyIds.tmpRt, result);
+
+            cb.ReleaseTemporaryRT(ShaderPropertyIds.tmpRt);
+            Profiler.EndSample();
+
+            return true;
+        }
+
+        private static void BlitSwapchain(CommandBuffer cb, ref RenderTargetIdentifier src, ref RenderTargetIdentifier dst, Material material, int pass)
+        {
+            cb.Blit(src, dst, material, pass);
+            (src, dst) = (dst, src);
+        }
+
+        private static void BlitSwapchain(CommandBuffer cb, ref RenderTargetIdentifier src, ref RenderTargetIdentifier dst, Material material)
+        {
+            cb.Blit(src, dst, material);
+            (src, dst) = (dst, src);
         }
     }
 }

--- a/Packages/src/Runtime/Effects/CompositeCanvasGlow.cs
+++ b/Packages/src/Runtime/Effects/CompositeCanvasGlow.cs
@@ -38,6 +38,7 @@ namespace CompositeCanvas.Effects
             innerCutoff = 0.8f;
             effectDistance = new Vector2(5, -5);
             blur = 1f;
+            blurMode = BlurMode.Uniform;
             iteration = 10;
             power = 1f;
             multiplier = 1f;

--- a/Packages/src/Runtime/Enums/BlurMode.cs
+++ b/Packages/src/Runtime/Enums/BlurMode.cs
@@ -1,0 +1,18 @@
+namespace CompositeCanvas.Enums
+{
+    /// <summary>
+    /// Defines how blur is applied.
+    /// <para />
+    /// <b>Uniform</b>: Applies the same blur radius to both the horizontal (X) and vertical (Y) axes.
+    /// <para />
+    /// <b>SeparateAxis</b>: Allows independent blur radii per axis (different strength for X and Y).
+    /// <para />
+    /// <b>Motion</b>: Applies a directional blur intended to simulate motion; typically elongated along a direction.
+    /// </summary>
+    public enum BlurMode
+    {
+        Uniform,
+        SeparateAxis,
+        Motion
+    }
+}

--- a/Packages/src/Runtime/Enums/BlurMode.cs.meta
+++ b/Packages/src/Runtime/Enums/BlurMode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6138500cacf04a60a5d5cc2bdae14051
+timeCreated: 1757086568


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds support for new blur modes as well as increases max value of blur radius.

**Key changes**
* Added blur modes: Uniform (default), Separate Axes and Motion blur
* Maximum value of blur is increased to 10

**Motivation**
* Need motion blur for animation
* Blur radius of 1 is not enough given the maximum amount of iterations allowed

<img width="440" height="237" alt="image" src="https://github.com/user-attachments/assets/18d8faf5-77fe-41e7-b7ca-21e6dd83a9cf" />
<br>
<img width="333" height="367" alt="image" src="https://github.com/user-attachments/assets/b7f090a1-06f7-446a-b2a5-575124c80ea1" />

## Type of change

Please write the commit message in the format corresponding to the change type.
Please see [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for more information.

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update documentations
- [ ] Others (refactoring, style changes, etc.)

## Test environment

- Platform: Editor(Linux)
- Unity version: 2022.3.59f1
- Build options: IL2CPP, .Net Standard 2.1, URP

## Checklist

- [x] This pull request is for merging into the `develop` branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
